### PR TITLE
Address issue #1 by adding an explicit dependency on the webxml plugin in BuildConfig.groovy

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,10 +1,10 @@
 #Grails Metadata file
-#Sun Jan 15 17:54:25 NOVT 2012
-app.grails.version=2.0.0
+#Fri Mar 09 20:20:54 EST 2012
+app.grails.version=2.0.1
 app.name=s2-facebook-example
 app.servlet.version=2.5
 app.version=0.1
 plugins.spring-security-core=1.2.7.2
 plugins.spring-security-facebook=0.6
-plugins.tomcat=2.0.0
-#plugins.webxml=1.4.1
+plugins.svn=1.0.0.M1
+plugins.tomcat=2.0.1

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -41,6 +41,7 @@ grails.project.dependency.resolution = {
         compile ":hibernate:$grailsVersion"
         compile ":jquery:1.6.1.1"
         compile ":resources:1.1.1"
+        compile ":webxml:1.4.1"
 
         //build ":tomcat:$grailsVersion"
     }


### PR DESCRIPTION
Details of the underlying problem with the Grails Resources plugin can
be found at http://jira.grails.org/browse/GPRESOURCES-122

Note that this also updates the project to Grails 2.0.1
